### PR TITLE
DOC: capitalize PyPI links

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,10 @@ content-type = "text/markdown"
 file = "README.md"
 
 [project.urls]
-changelog = "https://github.com/ComPWA/sphinx-hep-pdgref/releases"
-documentation = "https://github.com/ComPWA/sphinx-hep-pdgref/blob/main/README.md"
-issues = "https://github.com/ComPWA/sphinx-hep-pdgref/issues"
-source = "https://github.com/ComPWA/sphinx-hep-pdgref"
+Changelog = "https://github.com/ComPWA/sphinx-hep-pdgref/releases"
+Documentation = "https://github.com/ComPWA/sphinx-hep-pdgref/blob/main/README.md"
+Issues = "https://github.com/ComPWA/sphinx-hep-pdgref/issues"
+Source = "https://github.com/ComPWA/sphinx-hep-pdgref"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Links are currently not capitalized
[![](https://github.com/user-attachments/assets/92a30389-d579-42e4-af99-ba24f9ecabef)](https://pypi.org/project/sphinx-hep-pdgref/0.2.2/)
